### PR TITLE
Fix Shiny app type error with threshold

### DIFF
--- a/Scripts/Shiny/app.R
+++ b/Scripts/Shiny/app.R
@@ -277,7 +277,9 @@ get.max.cor <- function(variable){
 
 
 plot.slice <- function(variable, feature, maxcor, transparency,
-                       threshold, background, slice, axis, anatomy="All"){
+                       thresholdStr, background, slice, axis, anatomy="All"){
+
+  threshold <- as.double(thresholdStr)
 
   useAtlas <- anatomy != "All" & !is.null(atlas)
 


### PR DESCRIPTION
The p-value threshold was taken from the UI as a string
and then later treated as though it's a double.

I believe this didn't cause problems in older versions of... R? Shiny? Something.
So the [server](https://github.com/girder/optimal-transport-morphometry) does not need this fix.
However this is needed to make the shiny app work when following the readme instructions to run analysis on your local machine.